### PR TITLE
P8: Add default categories functionality

### DIFF
--- a/src/main/java/com/sapient/controller/UserController.java
+++ b/src/main/java/com/sapient/controller/UserController.java
@@ -4,6 +4,7 @@ import com.sapient.controller.record.DeleteSuccess;
 import com.sapient.exception.IncorrectPasswordException;
 import com.sapient.model.beans.User;
 import com.sapient.controller.record.FailurePayload;
+import com.sapient.model.service.DefaultCategoryService;
 import com.sapient.model.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.graphql.data.method.annotation.Argument;
@@ -16,6 +17,9 @@ import java.util.Optional;
 public class UserController {
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private DefaultCategoryService defaultCategoryService;
 
     @QueryMapping
     public String greeting() {
@@ -63,6 +67,7 @@ public class UserController {
             @Argument String phoneNumber) {
         try {
             User user = userService.createUser(username, password, email, firstName, lastName, phoneNumber);
+            defaultCategoryService.saveDefaultCategories(user);
             return new CreateUserSuccess(user.getPasswordHash(), user);
         } catch (Exception e) {
             return new FailurePayload(e.getClass().getSimpleName(), e.getMessage());

--- a/src/main/java/com/sapient/model/beans/DefaultCategory.java
+++ b/src/main/java/com/sapient/model/beans/DefaultCategory.java
@@ -1,0 +1,42 @@
+package com.sapient.model.beans;
+import javax.persistence.*;
+
+@Entity
+@Table(name = "default_categories")
+public class DefaultCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    private String colourHex;
+    private String name;
+    private String description;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getColourHex() {
+        return colourHex;
+    }
+
+    public void setColourHex(String colourHex) {
+        this.colourHex = colourHex;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/sapient/model/dao/DefaultCategoryRepository.java
+++ b/src/main/java/com/sapient/model/dao/DefaultCategoryRepository.java
@@ -1,0 +1,9 @@
+package com.sapient.model.dao;
+
+import com.sapient.model.beans.DefaultCategory;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DefaultCategoryRepository extends CrudRepository<DefaultCategory, Integer> {
+}

--- a/src/main/java/com/sapient/model/service/CategoryService.java
+++ b/src/main/java/com/sapient/model/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.sapient.exception.CategoryNotFoundException;
 import com.sapient.exception.NotAuthorizedException;
 import com.sapient.exception.UserNotFoundException;
 import com.sapient.model.beans.Category;
+import com.sapient.model.beans.DefaultCategory;
 import com.sapient.model.beans.User;
 import com.sapient.model.dao.CategoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,5 +93,16 @@ public class CategoryService {
     public Boolean categoryExists(Integer id) {
         Category category = categoryDao.findById(id).orElse(null);
         return category != null;
+    }
+
+    public void createCategoryFromDefaultCategory(User user, DefaultCategory defaultCategory){
+        Category category = new Category();
+
+        category.setUser(user);
+        category.setName(defaultCategory.getName());
+        category.setDescription(defaultCategory.getDescription());
+        category.setColourHex(defaultCategory.getColourHex());
+
+        categoryDao.save(category);
     }
 }

--- a/src/main/java/com/sapient/model/service/DefaultCategoryService.java
+++ b/src/main/java/com/sapient/model/service/DefaultCategoryService.java
@@ -1,0 +1,32 @@
+package com.sapient.model.service;
+
+import com.sapient.model.beans.DefaultCategory;
+import com.sapient.model.beans.User;
+import com.sapient.model.dao.DefaultCategoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class DefaultCategoryService {
+    @Autowired
+    private DefaultCategoryRepository defaultCategoryDao;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    public List<DefaultCategory> getDefaultCategories(){
+        Iterable<DefaultCategory> found = defaultCategoryDao.findAll();
+        List<DefaultCategory> defaultCategories = new ArrayList<>();
+        found.forEach(defaultCategories::add);
+        return defaultCategories;
+    }
+
+    public void saveDefaultCategories(User user){
+        for(DefaultCategory defaultCategory: getDefaultCategories()){
+            categoryService.createCategoryFromDefaultCategory(user, defaultCategory);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Add functionality for default categories.  
When a new user is created, the default_categories table is queried, and all of those categories are added to the categories table, with the correct user_id.

## Related Issue
- [ ] This pull request relates to at least one particular issue

  <!-- please update the issue number in the link below  -->
  - [issue name](https://github.com/ps-toronto-team-4/.github/issues/ISSUENUMBER)

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

**NOTE:** to test this functionality, you'll need to manually insert items into the default_categories table. Eventually, we'll create a script to automate this.