### PR TITLE
P8 Expense query now returns date as a string.

### DIFF
--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -95,6 +95,7 @@ type Expense {
 	amount: Float
 	title: String
 	description: String
+    date: String
 	user: User
 	category: Category
 	merchant: Merchant


### PR DESCRIPTION
## Description
Frontend requires expense query to return a date, so I added that to the schema.

## Related Issue
- [x] This pull request relates to at least one particular issue

  <!-- please update the issue number in the link below  -->
  - [Expenses](https://github.com/ps-toronto-team-4/.github/issues/8)

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

None
