### PR TITLE
I13 More sensible schema.

### DIFF
--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -28,8 +28,8 @@ type Query {
     categories(passwordHash: String!): CategoriesPayload!
     user(username: String!): User ## Helper for testing.
     signIn(username: String!, password: String!): SignInPayload!
-    merchant(passwordHash: String!, id: Int!): MerchantPayload
-    merchants(passwordHash: String!): MerchantsPayload
+    merchant(passwordHash: String!, id: Int!): MerchantPayload!
+    merchants(passwordHash: String!): MerchantsPayload!
 }
 
 type Mutation {
@@ -120,7 +120,7 @@ type MerchantSuccess {
 union MerchantsPayload = MerchantsSuccess | FailurePayload
 
 type MerchantsSuccess {
-    merchants: [Merchant]!
+    merchants: [Merchant!]!
 }
 
 union DeleteMerchantPayload = DeleteSuccess | FailurePayload


### PR DESCRIPTION
## Description
Merchants query is now required to return a payload (if some error occurred you should return a FailurePayload instead of possibly returning null). Merchants query success payload now must return an array of merchants instead of potentially returning an array of null values.

## Related Issue
- [x] This pull request relates to at least one particular issue

  <!-- please update the issue number in the link below  -->
  - [Add Expense](https://github.com/ps-toronto-team-4/.github/issues/13)

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

None
